### PR TITLE
Create Apple-inspired Pomodoro timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Focus Flow &mdash; Pomodoro Timer</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <p class="app__eyebrow">Focus Flow</p>
+        <h1 class="app__title">A mindful Pomodoro ritual</h1>
+        <p class="app__subtitle">
+          Stay present with an elegant timer that guides you through focused work
+          and restorative breaks.
+        </p>
+      </header>
+      <section class="timer-card" aria-live="polite">
+        <nav class="mode-selector" aria-label="Timer modes">
+          <button class="mode-button active" data-mode="pomodoro" aria-pressed="true">Focus</button>
+          <button class="mode-button" data-mode="short" aria-pressed="false">Pause</button>
+          <button class="mode-button" data-mode="long" aria-pressed="false">Restore</button>
+        </nav>
+        <div class="progress">
+          <svg class="progress__ring" viewBox="0 0 320 320" role="presentation">
+            <circle class="progress__ring-track" cx="160" cy="160" r="148" />
+            <circle
+              class="progress__ring-indicator"
+              cx="160"
+              cy="160"
+              r="148"
+            />
+          </svg>
+          <div class="time-display" id="time-display" aria-live="assertive">25:00</div>
+        </div>
+        <div class="controls" role="group" aria-label="Timer controls">
+          <button class="primary" id="start-stop">Start</button>
+          <button id="reset">Reset</button>
+        </div>
+        <dl class="session-details">
+          <div class="session-details__item">
+            <dt>Cycle</dt>
+            <dd id="cycle-count">1 of 4</dd>
+          </div>
+          <div class="session-details__item">
+            <dt>Mode</dt>
+            <dd id="mode-label">Focus</dd>
+          </div>
+          <div class="session-details__item">
+            <dt>Next</dt>
+            <dd id="next-label">Pause</dd>
+          </div>
+        </dl>
+      </section>
+      <footer class="app__footer">
+        <p>
+          Tip: After four focus sessions enjoy an extended break to let your mind
+          reset. Your progress is quietly saved if you keep the tab open.
+        </p>
+      </footer>
+    </main>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,233 @@
+const MODES = {
+  pomodoro: { label: "Focus", duration: 25 * 60 },
+  short: { label: "Pause", duration: 5 * 60 },
+  long: { label: "Restore", duration: 15 * 60 }
+};
+
+const state = {
+  mode: "pomodoro",
+  remaining: MODES.pomodoro.duration,
+  isRunning: false,
+  targetTime: null,
+  rafId: null,
+  focusRound: 1
+};
+
+const timeDisplay = document.getElementById("time-display");
+const startStopBtn = document.getElementById("start-stop");
+const resetBtn = document.getElementById("reset");
+const modeButtons = Array.from(document.querySelectorAll(".mode-button"));
+const cycleCountEl = document.getElementById("cycle-count");
+const modeLabelEl = document.getElementById("mode-label");
+const nextLabelEl = document.getElementById("next-label");
+const progressRing = document.querySelector(".progress__ring-indicator");
+
+const RADIUS = 148;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+progressRing.style.strokeDasharray = `${CIRCUMFERENCE} ${CIRCUMFERENCE}`;
+progressRing.style.strokeDashoffset = 0;
+progressRing.style.transition = "stroke-dashoffset 600ms cubic-bezier(0.4, 0, 0.2, 1)";
+
+let audioCtx;
+
+function ensureAudioContext(fromInteraction = false) {
+  const AudioContext = window.AudioContext || window.webkitAudioContext;
+  if (!AudioContext) {
+    return null;
+  }
+  if (!audioCtx) {
+    audioCtx = new AudioContext();
+  }
+  if (fromInteraction && audioCtx.state === "suspended") {
+    audioCtx.resume();
+  }
+  return audioCtx;
+}
+
+function formatTime(totalSeconds) {
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = Math.floor(totalSeconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+
+function updateProgress(remainingSeconds) {
+  const duration = MODES[state.mode].duration;
+  const safeRemaining = Math.max(0, Math.min(duration, remainingSeconds));
+  const progress = 1 - safeRemaining / duration;
+  progressRing.style.strokeDashoffset = CIRCUMFERENCE * progress;
+}
+
+function updateUI(fractionalRemaining) {
+  const secondsLeft =
+    typeof fractionalRemaining === "number"
+      ? Math.max(0, fractionalRemaining)
+      : state.remaining;
+  const displaySeconds = Math.ceil(secondsLeft);
+  timeDisplay.textContent = formatTime(displaySeconds);
+  document.title = `${MODES[state.mode].label} • ${formatTime(displaySeconds)} — Focus Flow`;
+  updateProgress(secondsLeft);
+  cycleCountEl.textContent = `Focus ${state.focusRound} of 4`;
+  modeLabelEl.textContent = MODES[state.mode].label;
+  nextLabelEl.textContent = getNextLabel();
+}
+
+function getNextLabel() {
+  if (state.mode === "pomodoro") {
+    return state.focusRound === 4 ? MODES.long.label : MODES.short.label;
+  }
+  return MODES.pomodoro.label;
+}
+
+function cancelTimer() {
+  if (state.rafId) {
+    cancelAnimationFrame(state.rafId);
+    state.rafId = null;
+  }
+}
+
+function updateModeButtons() {
+  modeButtons.forEach((button) => {
+    const isActive = button.dataset.mode === state.mode;
+    button.classList.toggle("active", isActive);
+    button.setAttribute("aria-pressed", String(isActive));
+  });
+}
+
+function setRingTransition(active) {
+  progressRing.style.transition = active
+    ? "stroke-dashoffset 600ms cubic-bezier(0.4, 0, 0.2, 1)"
+    : "none";
+}
+
+function pauseTimer() {
+  if (!state.isRunning) return;
+  state.isRunning = false;
+  cancelTimer();
+  if (state.targetTime) {
+    const remaining = Math.max(0, (state.targetTime - Date.now()) / 1000);
+    state.remaining = Math.ceil(remaining);
+  }
+  state.targetTime = null;
+  startStopBtn.textContent = "Resume";
+  setRingTransition(true);
+  updateUI();
+}
+
+function startTimer() {
+  if (state.isRunning) {
+    pauseTimer();
+    return;
+  }
+  state.isRunning = true;
+  const now = Date.now();
+  state.targetTime = now + state.remaining * 1000;
+  startStopBtn.textContent = "Pause";
+  setRingTransition(false);
+  step();
+}
+
+function step() {
+  if (!state.isRunning || !state.targetTime) return;
+  const remaining = (state.targetTime - Date.now()) / 1000;
+  if (remaining <= 0) {
+    state.remaining = 0;
+    updateUI(0);
+    completeSession();
+    return;
+  }
+  state.remaining = Math.ceil(remaining);
+  updateUI(remaining);
+  state.rafId = requestAnimationFrame(step);
+}
+
+function setMode(mode) {
+  cancelTimer();
+  state.mode = mode;
+  state.remaining = MODES[mode].duration;
+  state.targetTime = null;
+  state.isRunning = false;
+  startStopBtn.textContent = "Start";
+  updateModeButtons();
+  setRingTransition(true);
+  updateUI();
+}
+
+function resetTimer() {
+  state.focusRound = 1;
+  setMode("pomodoro");
+}
+
+function playChime() {
+  try {
+    const ctx = ensureAudioContext();
+    if (!ctx) return;
+    const duration = 1.2;
+    const now = ctx.currentTime;
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+
+    oscillator.type = "sine";
+    oscillator.frequency.setValueAtTime(880, now);
+    oscillator.frequency.exponentialRampToValueAtTime(660, now + duration);
+
+    gain.gain.setValueAtTime(0.001, now);
+    gain.gain.exponentialRampToValueAtTime(0.1, now + 0.05);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+    oscillator.connect(gain).connect(ctx.destination);
+    oscillator.start(now);
+    oscillator.stop(now + duration);
+  } catch (error) {
+    console.warn("Chime unavailable", error);
+  }
+}
+
+function completeSession() {
+  playChime();
+  if (state.mode === "pomodoro") {
+    if (state.focusRound === 4) {
+      state.focusRound = 1;
+      setMode("long");
+    } else {
+      state.focusRound += 1;
+      setMode("short");
+    }
+  } else {
+    setMode("pomodoro");
+  }
+}
+
+startStopBtn.addEventListener("click", () => {
+  ensureAudioContext(true);
+  if (state.isRunning) {
+    pauseTimer();
+  } else {
+    startTimer();
+  }
+});
+
+resetBtn.addEventListener("click", () => {
+  resetTimer();
+});
+
+modeButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const mode = button.dataset.mode;
+    if (mode === state.mode) return;
+    cancelTimer();
+    state.mode = mode;
+    state.remaining = MODES[mode].duration;
+    state.targetTime = null;
+    state.isRunning = false;
+    startStopBtn.textContent = "Start";
+    updateModeButtons();
+    updateUI();
+  });
+});
+
+setRingTransition(true);
+updateUI();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,377 @@
+:root {
+  color-scheme: light dark;
+  --bg-gradient: radial-gradient(circle at 20% 20%, #f1f6ff, #e0e8ff 35%, #cbd7ff 65%, #b9c4ff);
+  --bg-gradient-dark: radial-gradient(circle at 20% 20%, #030712, #0c1224 35%, #111a33 65%, #0a1122);
+  --card-light: rgba(255, 255, 255, 0.75);
+  --card-dark: rgba(12, 16, 32, 0.65);
+  --surface-blur: saturate(180%) blur(40px);
+  --text-primary: #0b132b;
+  --text-secondary: rgba(11, 19, 43, 0.65);
+  --text-primary-dark: #f5f7ff;
+  --text-secondary-dark: rgba(245, 247, 255, 0.65);
+  --accent: #3855ff;
+  --accent-soft: rgba(56, 85, 255, 0.12);
+  --accent-strong: rgba(56, 85, 255, 0.25);
+  --success: #2bc48a;
+  --danger: #ff6f61;
+  --font-sans: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Helvetica Neue", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  display: grid;
+  place-items: center;
+  padding: clamp(2rem, 3vw, 4rem);
+  transition: background 600ms ease;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: -25% -20%;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.6), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(56, 85, 255, 0.28), transparent 55%),
+    radial-gradient(circle at 10% 80%, rgba(43, 196, 138, 0.18), transparent 55%);
+  filter: blur(90px);
+  z-index: -1;
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--bg-gradient-dark);
+    color: var(--text-primary-dark);
+  }
+
+  body::before {
+    background: radial-gradient(circle at 25% 25%, rgba(78, 110, 255, 0.45), transparent 55%),
+      radial-gradient(circle at 70% 15%, rgba(134, 96, 255, 0.3), transparent 55%),
+      radial-gradient(circle at 30% 85%, rgba(43, 196, 138, 0.22), transparent 55%);
+    opacity: 0.55;
+  }
+}
+
+.app {
+  max-width: 960px;
+  width: min(100%, 840px);
+  display: grid;
+  gap: 3rem;
+}
+
+.app__header {
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.app__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  margin: 0;
+  color: var(--accent);
+}
+
+.app__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.8rem);
+  font-weight: 700;
+}
+
+.app__subtitle {
+  margin: 0 auto;
+  max-width: 46ch;
+  color: var(--text-secondary);
+  font-size: clamp(1rem, 2.4vw, 1.25rem);
+}
+
+@media (prefers-color-scheme: dark) {
+  .app__subtitle {
+    color: var(--text-secondary-dark);
+  }
+}
+
+.timer-card {
+  position: relative;
+  margin: 0 auto;
+  padding: clamp(2.5rem, 4vw, 3.5rem);
+  border-radius: 48px;
+  background: var(--card-light);
+  box-shadow: 0 40px 60px rgba(24, 48, 96, 0.12);
+  backdrop-filter: var(--surface-blur);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.timer-card::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.05));
+  opacity: 0.55;
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .timer-card {
+    background: var(--card-dark);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 40px 60px rgba(0, 0, 0, 0.45);
+  }
+
+  .timer-card::before {
+    background: linear-gradient(135deg, rgba(120, 140, 255, 0.35), rgba(40, 50, 80, 0.45));
+    opacity: 0.4;
+  }
+}
+
+.mode-selector {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  background: rgba(56, 85, 255, 0.12);
+  padding: 0.5rem;
+  border-radius: 999px;
+}
+
+.mode-button {
+  position: relative;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0.85rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 200ms ease, background 200ms ease, color 200ms ease;
+}
+
+.mode-button.active {
+  background: white;
+  color: var(--accent);
+  box-shadow: 0 10px 18px rgba(56, 85, 255, 0.25);
+}
+
+.mode-button:not(.active):hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+@media (prefers-color-scheme: dark) {
+  .mode-selector {
+    background: rgba(56, 85, 255, 0.18);
+  }
+
+  .mode-button.active {
+    background: rgba(56, 85, 255, 0.16);
+    color: #fff;
+  }
+
+  .mode-button:not(.active):hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.progress {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.progress__ring {
+  width: min(64vw, 320px);
+  height: min(64vw, 320px);
+  filter: drop-shadow(0 20px 40px rgba(56, 85, 255, 0.35));
+}
+
+.progress__ring-track {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.35);
+  stroke-width: 10;
+}
+
+.progress__ring-indicator {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 10;
+  stroke-linecap: round;
+  stroke-dasharray: 929;
+  stroke-dashoffset: 0;
+  transform-origin: 50% 50%;
+  transform: rotate(-90deg);
+  transition: stroke-dashoffset 500ms ease;
+}
+
+.time-display {
+  position: absolute;
+  font-size: clamp(3.5rem, 8vw, 4.8rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.controls {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+button {
+  font: inherit;
+  border-radius: 999px;
+  padding: 0.85rem 2.4rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.45);
+  color: inherit;
+  transition: transform 150ms ease, box-shadow 200ms ease, background 200ms ease,
+    color 200ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.65);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+.primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 15px 25px rgba(56, 85, 255, 0.35);
+}
+
+.primary:hover {
+  background: #1d35ff;
+}
+
+@media (prefers-color-scheme: dark) {
+  button {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+
+  button:hover {
+    background: rgba(255, 255, 255, 0.14);
+  }
+
+  .primary {
+    background: linear-gradient(135deg, #3356ff, #7788ff);
+  }
+
+  .primary:hover {
+    background: linear-gradient(135deg, #2a46ff, #6676ff);
+  }
+}
+
+.session-details {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+  margin: 0;
+  padding: 1.5rem;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.45);
+}
+
+.session-details__item {
+  text-align: center;
+}
+
+.session-details dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--text-secondary);
+  margin-bottom: 0.4rem;
+}
+
+.session-details dd {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+@media (prefers-color-scheme: dark) {
+  .session-details {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .session-details dt {
+    color: var(--text-secondary-dark);
+  }
+}
+
+.app__footer {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .app__footer {
+    color: var(--text-secondary-dark);
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    gap: 2.25rem;
+  }
+
+  .timer-card {
+    border-radius: 32px;
+  }
+
+  .session-details {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+}
+
+@media (max-width: 420px) {
+  .mode-selector {
+    gap: 0.5rem;
+  }
+
+  .mode-button {
+    padding: 0.75rem 0.5rem;
+  }
+
+  .controls {
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page Focus Flow Pomodoro interface with focus, pause, and restore modes
- implement the timer logic with animated progress ring, cycle tracking, and contextual chime
- design a glassmorphic, Apple-inspired aesthetic with responsive layouts and dark-mode accents

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d052eaf87c8332aec450481b61fabb